### PR TITLE
feat: add OpenRouter provider preferences support

### DIFF
--- a/docs/openrouter_provider.md
+++ b/docs/openrouter_provider.md
@@ -1,0 +1,120 @@
+# OpenRouter Provider Support
+
+This feature adds support for OpenRouter's provider preferences, allowing you to control how your requests are routed across different AI model providers.
+
+## Configuration
+
+### Environment Variables
+
+You can configure provider preferences using environment variables:
+
+```bash
+# Provider order - comma-separated list of provider slugs
+OPENROUTER_PROVIDER_ORDER=anthropic,openai,deepinfra
+
+# Allow fallbacks to other providers (true/false)
+OPENROUTER_ALLOW_FALLBACKS=true
+
+# Require providers to support all parameters (true/false)
+OPENROUTER_REQUIRE_PARAMETERS=false
+
+# Data collection preference (allow/deny)
+OPENROUTER_DATA_COLLECTION=allow
+
+# Only use these providers - comma-separated list
+OPENROUTER_PROVIDER_ONLY=anthropic,openai
+
+# Ignore these providers - comma-separated list
+OPENROUTER_PROVIDER_IGNORE=deepinfra
+
+# Quantization levels - comma-separated list (int4, int8, fp4, fp6, fp8, fp16, bf16, fp32)
+OPENROUTER_QUANTIZATIONS=fp16,bf16
+
+# Sort providers by (price/throughput/latency)
+OPENROUTER_SORT=throughput
+
+# Maximum price constraints (JSON format)
+OPENROUTER_MAX_PRICE='{"prompt": 1, "completion": 2}'
+```
+
+### Configuration File
+
+You can also configure provider preferences in your settings.json or when initializing the Config:
+
+```javascript
+const config = new Config({
+  // ... other config options
+  providerPreferences: {
+    order: ['anthropic', 'openai'],
+    allow_fallbacks: true,
+    require_parameters: false,
+    data_collection: 'allow',
+    only: ['anthropic', 'openai'],
+    ignore: ['deepinfra'],
+    quantizations: ['fp16', 'bf16'],
+    sort: 'throughput',
+    max_price: {
+      prompt: 1,
+      completion: 2
+    }
+  }
+});
+```
+
+## How It Works
+
+When using the OpenAI auth type with OpenRouter, the provider preferences are automatically included in the API request body as a `provider` object. This allows OpenRouter to route your requests according to your preferences.
+
+### Priority
+
+1. Environment variables take precedence over configuration file settings
+2. Any provider preferences set will be included in requests to OpenRouter
+3. If no preferences are set, OpenRouter will use its default routing strategy
+
+## Examples
+
+### Prioritize Specific Providers
+
+```bash
+# Use Anthropic first, then OpenAI, with no fallbacks
+OPENROUTER_PROVIDER_ORDER=anthropic,openai
+OPENROUTER_ALLOW_FALLBACKS=false
+```
+
+### Optimize for Performance
+
+```bash
+# Sort by throughput for fastest responses
+OPENROUTER_SORT=throughput
+```
+
+### Budget Constraints
+
+```bash
+# Limit costs to $1 per million prompt tokens, $2 per million completion tokens
+OPENROUTER_MAX_PRICE='{"prompt": 1, "completion": 2}'
+OPENROUTER_SORT=price
+```
+
+### Privacy-Focused
+
+```bash
+# Only use providers that don't collect data
+OPENROUTER_DATA_COLLECTION=deny
+```
+
+### Specific Quantization
+
+```bash
+# Only use FP16 or BF16 models
+OPENROUTER_QUANTIZATIONS=fp16,bf16
+```
+
+## Shortcuts
+
+The implementation also supports OpenRouter's shortcuts:
+
+- Append `:nitro` to model names to sort by throughput
+- Append `:floor` to model names to sort by price
+
+These shortcuts work automatically without any additional configuration.

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -159,6 +159,22 @@ export interface ConfigParameters {
     modelNames?: string[];
     template?: string;
   }>;
+  providerPreferences?: {
+    order?: string[];
+    allow_fallbacks?: boolean;
+    require_parameters?: boolean;
+    data_collection?: 'allow' | 'deny';
+    only?: string[];
+    ignore?: string[];
+    quantizations?: string[];
+    sort?: string;
+    max_price?: {
+      prompt?: number;
+      completion?: number;
+      request?: number;
+      image?: number;
+    };
+  };
 }
 
 export class Config {
@@ -214,6 +230,22 @@ export class Config {
     modelNames?: string[];
     template?: string;
   }>;
+  private readonly providerPreferences?: {
+    order?: string[];
+    allow_fallbacks?: boolean;
+    require_parameters?: boolean;
+    data_collection?: 'allow' | 'deny';
+    only?: string[];
+    ignore?: string[];
+    quantizations?: string[];
+    sort?: string;
+    max_price?: {
+      prompt?: number;
+      completion?: number;
+      request?: number;
+      image?: number;
+    };
+  };
   private modelSwitchedDuringSession: boolean = false;
   private readonly maxSessionTurns: number;
   private readonly sessionTokenLimit: number;
@@ -273,6 +305,7 @@ export class Config {
     this.enableOpenAILogging = params.enableOpenAILogging ?? false;
     this.sampling_params = params.sampling_params;
     this.systemPromptMappings = params.systemPromptMappings;
+    this.providerPreferences = params.providerPreferences;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -305,6 +338,7 @@ export class Config {
     this.contentGeneratorConfig = await createContentGeneratorConfig(
       this.model,
       authMethod,
+      this.providerPreferences,
     );
     this.contentGeneratorConfig.enableOpenAILogging = this.enableOpenAILogging;
 
@@ -572,6 +606,27 @@ export class Config {
       }>
     | undefined {
     return this.systemPromptMappings;
+  }
+
+  getProviderPreferences():
+    | {
+        order?: string[];
+        allow_fallbacks?: boolean;
+        require_parameters?: boolean;
+        data_collection?: 'allow' | 'deny';
+        only?: string[];
+        ignore?: string[];
+        quantizations?: string[];
+        sort?: string;
+        max_price?: {
+          prompt?: number;
+          completion?: number;
+          request?: number;
+          image?: number;
+        };
+      }
+    | undefined {
+    return this.providerPreferences;
   }
 
   async refreshMemory(): Promise<{ memoryContent: string; fileCount: number }> {

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -195,6 +195,13 @@ export class OpenAIContentGenerator implements ContentGenerator {
           request.config.tools,
         );
       }
+
+      // Add OpenRouter provider preferences if configured
+      const providerPreferences = this.config.getContentGeneratorConfig()?.providerPreferences;
+      if (providerPreferences && Object.keys(providerPreferences).length > 0) {
+        // TypeScript might complain about this, but OpenRouter accepts it
+        (createParams as any).provider = providerPreferences;
+      }
       // console.log('createParams', createParams);
       const completion = (await this.client.chat.completions.create(
         createParams,
@@ -320,6 +327,13 @@ export class OpenAIContentGenerator implements ContentGenerator {
         createParams.tools = await this.convertGeminiToolsToOpenAI(
           request.config.tools,
         );
+      }
+
+      // Add OpenRouter provider preferences if configured
+      const providerPreferences = this.config.getContentGeneratorConfig()?.providerPreferences;
+      if (providerPreferences && Object.keys(providerPreferences).length > 0) {
+        // TypeScript might complain about this, but OpenRouter accepts it
+        (createParams as any).provider = providerPreferences;
       }
 
       // console.log('createParams', createParams);


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for OpenRouter's provider preferences, allowing users to control how their requests are routed across different AI model providers.

## Changes

- Added `providerPreferences` configuration to `ContentGeneratorConfig` and `Config` classes
- Support loading provider preferences from environment variables (`OPENROUTER_*`)
- Pass provider object in OpenAI API requests for both streaming and non-streaming
- Environment variables take precedence over config file settings
- Added comprehensive documentation in `docs/openrouter_provider.md`

## Supported Provider Preferences

- **Provider order**: Specify preferred provider order (e.g., `anthropic,openai`)
- **Fallback control**: Enable/disable fallbacks (`allow_fallbacks`)
- **Sorting**: Sort providers by price, throughput, or latency
- **Provider filtering**: Use only specific providers or ignore certain ones
- **Quantization levels**: Filter by quantization (e.g., `fp16,bf16`)
- **Price constraints**: Set maximum price limits for prompts/completions
- **Data collection**: Control data collection preferences (`allow`/`deny`)
- **Parameter requirements**: Require providers to support all parameters

## Configuration

### Environment Variables
```bash
OPENROUTER_PROVIDER_ORDER=anthropic,openai
OPENROUTER_ALLOW_FALLBACKS=true
OPENROUTER_SORT=throughput
OPENROUTER_MAX_PRICE='{"prompt": 1, "completion": 2}'
# ... and more
```

### Config File
```javascript
const config = new Config({
  providerPreferences: {
    order: ['anthropic', 'openai'],
    sort: 'throughput',
    // ... other preferences
  }
});
```

## Testing

The implementation has been tested to ensure:
- Provider preferences are correctly parsed from environment variables
- Config file preferences are properly loaded
- Environment variables take precedence over config settings
- The provider object is included in API requests when preferences are set

## Documentation

Complete documentation is available in `docs/openrouter_provider.md` with examples for common use cases.